### PR TITLE
fix: use npm build in CI workflow

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -1,4 +1,4 @@
-name: NodeJS with Gulp
+name: NodeJS CI
 
 on:
   push:
@@ -24,5 +24,5 @@ jobs:
 
     - name: Build
       run: |
-        npm install
-        gulp
+        npm ci
+        npm run build


### PR DESCRIPTION
## Summary
- replace gulp step with npm build in CI workflow

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a6736ef5cc8325bcc3246e9b6eb63e